### PR TITLE
Fix ROS 1 build script

### DIFF
--- a/minipupper_ros1/config.yaml
+++ b/minipupper_ros1/config.yaml
@@ -5,12 +5,14 @@ mini-pupper-ros1:
   image: focal
   cloud_init: ./cloud-config.yaml
   git_repos:
+    - https://github.com/hdumcke/multipass-orchestrator-configurations.git
     - https://github.com/hdumcke/mini_pupper_testig.git
   build_scripts:
     - ./mini_pupper_testig/bsp_ros1/setup_testing.sh
+    - ./multipass-orchestrator-configurations/minipupper_ros1/setup_roshostname_minipupper.sh
 ros1:
   cpu: 4
-  mem: 16G
+  mem: 4G
   disk: 10G
   image: focal
   cloud_init: ./cloud-config.yaml
@@ -20,3 +22,4 @@ ros1:
   build_scripts:
     - ./multipass-orchestrator-configurations/ubuntu-desktop/build.sh
     - ./mini_pupper_testig/bsp_ros1/setup_pc.sh
+    - ./multipass-orchestrator-configurations/minipupper_ros1/setup_roshostname_pc.sh

--- a/minipupper_ros1/setup_roshostname_minipupper.sh
+++ b/minipupper_ros1/setup_roshostname_minipupper.sh
@@ -1,0 +1,3 @@
+
+echo "export ROS_HOSTNAME=mini-pupper-ros1" >> ~/.bashrc
+echo "export ROS_MASTER_URI=http://mini-pupper-ros1:11311" >> ~/.bashrc

--- a/minipupper_ros1/setup_roshostname_pc.sh
+++ b/minipupper_ros1/setup_roshostname_pc.sh
@@ -1,0 +1,3 @@
+
+echo "export ROS_HOSTNAME=ros1" >> ~/.bashrc
+echo "export ROS_MASTER_URI=http://mini-pupper-ros1:11311" >> ~/.bashrc


### PR DESCRIPTION
This pull request depends on https://github.com/hdumcke/mini_pupper_testig/pull/1

We can test this pull request without merging with the following `config.yaml`.

```yaml
mini-pupper-ros1:
  cpu: 2
  mem: 2G
  disk: 5G
  image: focal
  cloud_init: ./cloud-config.yaml
  git_repos:
    - https://github.com/Tiryoh/multipass-orchestrator-configurations.git -b PR1
    - https://github.com/Tiryoh/mini_pupper_testig.git -b PR1
  build_scripts:
    - ./mini_pupper_testig/bsp_ros1/setup_testing.sh
    - ./multipass-orchestrator-configurations/minipupper_ros1/setup_roshostname_minipupper.sh
ros1:
  cpu: 4
  mem: 4G
  disk: 10G
  image: focal
  cloud_init: ./cloud-config.yaml
  git_repos:
    - https://github.com/Tiryoh/multipass-orchestrator-configurations.git -b PR1
    - https://github.com/Tiryoh/mini_pupper_testig.git -b PR1
  build_scripts:
    - ./multipass-orchestrator-configurations/ubuntu-desktop/build.sh
    - ./mini_pupper_testig/bsp_ros1/setup_pc.sh
    - ./multipass-orchestrator-configurations/minipupper_ros1/setup_roshostname_pc.sh
```

After `mpo-deploy config.yaml`, we can see that the setup has been succeeded without critical errors.

```
ubuntu@ros1:~$ tail -n10 ~/.build_out.log 
Devel space: /home/ubuntu/catkin_ws/devel
Install space: /home/ubuntu/catkin_ws/install
Creating symlink "/home/ubuntu/catkin_ws/src/CMakeLists.txt" pointing to "/opt/ros/noetic/share/catkin/cmake/toplevel.cmake"
####
#### Running command: "cmake /home/ubuntu/catkin_ws/src -DCATKIN_DEVEL_PREFIX=/home/ubuntu/catkin_ws/devel -DCMAKE_INSTALL_PREFIX=/home/ubuntu/catkin_ws/install -G Unix Makefiles" in "/home/ubuntu/catkin_ws/build"
####
####
#### Running command: "make -j4 -l4" in "/home/ubuntu/catkin_ws/build"
####
setup_pc.sh executed.

ubuntu@ros1:~$ tail -n10 ~/.build_err.log
debconf: falling back to frontend: Teletype
dpkg-preconfigure: unable to re-open stdin: 
debconf: unable to initialize frontend: Dialog
debconf: (Dialog frontend will not work on a dumb terminal, an emacs shell buffer, or without a controlling terminal.)
debconf: falling back to frontend: Readline
debconf: unable to initialize frontend: Readline
debconf: (This frontend requires a controlling tty.)
debconf: falling back to frontend: Teletype
dpkg-preconfigure: unable to re-open stdin: 
Created symlink /etc/systemd/system/multi-user.target.wants/robot.service → /etc/systemd/system/robot.service.
```